### PR TITLE
コメントを付けられるようにする

### DIFF
--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Books::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+
+  def set_commentable
+    @commentable = Book.find(params[:book_id])
+  end
+end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -11,7 +11,9 @@ class BooksController < ApplicationController
 
   # GET /books/1
   # GET /books/1.json
-  def show; end
+  def show
+    @comments = @book.comments
+  end
 
   # GET /books/new
   def new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  def show
+    @comment = @commentable.comments.find(params[:id])
+  end
+
+  def new
+    @comment = Comment.new
+  end
+
+  def create
+    @comment = @commentable.comments.build(comment_params)
+    if @comment.save
+      redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @comment = @commentable.comments.find(params[:id])
+  end
+
+  def update
+    @comment = @commentable.comments.find(params[:id])
+    if @comment.update(comment_params)
+      redirect_to @commentable, notice: t('controllers.common.notice_update', name: Comment.model_name.human)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @comment = @commentable.comments.find(params[:id])
+    if @comment.destroy
+      redirect_to @commentable, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+    else
+      redirect_to @commentable
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content).merge(user_id: current_user.id)
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -24,6 +24,8 @@ class CommentsController < ApplicationController
 
   def update
     @comment = @commentable.comments.find(params[:id])
+    redirect_to @commentable unless current_user.id == @comment.user_id
+
     if @comment.update(comment_params)
       redirect_to @commentable, notice: t('controllers.common.notice_update', name: Comment.model_name.human)
     else
@@ -33,6 +35,8 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment = @commentable.comments.find(params[:id])
+    redirect_to @commentable unless current_user.id == @comment.user_id
+
     if @comment.destroy
       redirect_to @commentable, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
     else

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Reports::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+
+  def set_commentable
+    @commentable = Report.find(params[:report_id])
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,12 +21,10 @@ class ReportsController < ApplicationController
     else
       render :new
     end
-
   end
 
   def edit
     @report = Report.find(params[:id])
-
   end
 
   def update
@@ -36,7 +34,6 @@ class ReportsController < ApplicationController
     else
       render :edit
     end
-
   end
 
   def destroy

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class ReportsController < ApplicationController
+  def index
+    @reports = Report.order(:id).page(params[:page])
+  end
+
+  def show
+    @report = Report.find(params[:id])
+  end
+
+  def new
+    @report = Report.new
+  end
+
+  def create
+    @report = Report.new(report_params)
+
+    if @report.save
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+    else
+      render :new
+    end
+
+  end
+
+  def edit
+    @report = Report.find(params[:id])
+
+  end
+
+  def update
+    @report = Report.find(params[:id])
+    if @report.update(report_params)
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit
+    end
+
+  end
+
+  def destroy
+    @report = Report.find(params[:id])
+    if @report.destroy
+      redirect_to @report, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
+    else
+      redirect_to @report
+    end
+  end
+
+  private
+
+  def report_params
+    params.require(:report).permit(:title, :content).merge(user_id: current_user.id)
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -7,6 +7,7 @@ class ReportsController < ApplicationController
 
   def show
     @report = Report.find(params[:id])
+    @comments = @report.comments
   end
 
   def new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -30,6 +30,8 @@ class ReportsController < ApplicationController
 
   def update
     @report = Report.find(params[:id])
+    redirect_to @report unless current_user.id == @report.user_id
+
     if @report.update(report_params)
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
@@ -39,6 +41,8 @@ class ReportsController < ApplicationController
 
   def destroy
     @report = Report.find(params[:id])
+    redirect_to @report unless current_user.id == @report.user_id
+
     if @report.destroy
       redirect_to @report, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
     else

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,6 +15,6 @@ class Comment < ApplicationRecord
   end
 
   def format_time
-    created_at.strftime('%Y/%m/%d %H:%M')
+    I18n.l created_at, format: :long
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,8 +6,12 @@ class Comment < ApplicationRecord
   validates :content, presence: true
 
   def user_name
-    user_id = self.user_id
-    User.find(user_id).name
+    user = User.find(user_id)
+    if user.name.nil?
+      user.email
+    else
+      user.name
+    end
   end
 
   def format_time

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,7 +7,7 @@ class Comment < ApplicationRecord
 
   def user_name
     user = User.find(user_id)
-    if user.name.nil?
+    if user.name.empty?
       user.email
     else
       user.name

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :commentable, polymorphic: true
+  validates :content, presence: true
+
+  def user_name
+    user_id = self.user_id
+    User.find(user_id).name
+  end
+
+  def format_time
+    created_at.strftime('%Y/%m/%d %H:%M')
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
 class Report < ApplicationRecord
-  belong_to :user
+  belongs_to :user
+  validates :title, presence: true
+  validates :content, presence: true
+
+  def format_time
+    self.created_at.strftime('%Y/%m/%d %H:%M')
+  end
+
+  def user_name
+    user_id = self.user_id
+    User.find(user_id).name
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,7 +7,7 @@ class Report < ApplicationRecord
   validates :content, presence: true
 
   def format_time
-    created_at.strftime('%Y/%m/%d %H:%M')
+    I18n.l created_at, format: :long
   end
 
   def user_name

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,11 +2,12 @@
 
 class Report < ApplicationRecord
   belongs_to :user
+  has_many :comments, as: :commentable, dependent: :destroy
   validates :title, presence: true
   validates :content, presence: true
 
   def format_time
-    self.created_at.strftime('%Y/%m/%d %H:%M')
+    created_at.strftime('%Y/%m/%d %H:%M')
   end
 
   def user_name

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Report < ApplicationRecord
+  belong_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
+  has_many :reports, dependent: :destroy
+
   def following?(user)
     active_relationships.where(following_id: user.id).exists?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_one_attached :avatar
 
   has_many :reports, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   def following?(user)
     active_relationships.where(following_id: user.id).exists?

--- a/app/views/books/comments/edit.html.erb
+++ b/app/views/books/comments/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
+
+<%= render 'comments/comments', commentable: @commentable, comment: @comment %>

--- a/app/views/books/comments/show.html.erb
+++ b/app/views/books/comments/show.html.erb
@@ -1,0 +1,1 @@
+<%= render 'comments/show', commentable: @commentable, comment: @comment %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,5 +20,9 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
+<%= render 'comments/index', commentable: @book, comments: @comments %>
+
+<%= render 'comments/form', commentable: @book, comment: Comment.new %>
+
 <%= link_to t('views.common.edit'), edit_book_path(@book) %> |
 <%= link_to t('views.common.back'), books_path %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: [commentable, comment] do |f| %>
+  <%= f.text_area :content %><br>
+  <%= f.submit %>
+<% end %>

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -1,0 +1,21 @@
+<h2><%= Comment.model_name.human %></h2>
+<table>
+  <thead>
+    <tr>
+      <th><%= Comment.human_attribute_name(:user_id) %></th>
+      <th><%= Comment.human_attribute_name(:content) %></th>
+      <th><%= Comment.human_attribute_name(:created_at) %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% comments.each do |comment| %>
+      <tr>
+        <td><%= comment.user_name %></td>
+        <td><%= comment.content %></td>
+        <td><%= comment.format_time %></td>
+        <td><%= link_to t('views.common.show'), polymorphic_url([commentable, comment]) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -2,7 +2,7 @@
 <table>
   <thead>
     <tr>
-      <th><%= Comment.human_attribute_name(:user_id) %></th>
+      <th><%= Comment.human_attribute_name(:user_name) %></th>
       <th><%= Comment.human_attribute_name(:content) %></th>
       <th><%= Comment.human_attribute_name(:created_at) %></th>
     </tr>

--- a/app/views/comments/_show.html.erb
+++ b/app/views/comments/_show.html.erb
@@ -1,0 +1,22 @@
+<h1><%= t('views.common.title_show', name: Comment.model_name.human) %></h1>
+<p>
+  <strong><%= Comment.human_attribute_name(:user_name) %>:</strong>
+  <%= @comment.user_name %>
+</p>
+
+<p>
+  <strong><%= Comment.human_attribute_name(:content) %>:</strong>
+  <%= @comment.content %>
+</p>
+
+<p>
+  <strong><%= Comment.human_attribute_name(:created_at) %>:</strong>
+  <%= @comment.format_time %>
+</p>
+
+<% if current_user.id == comment.user_id %>
+  <%= link_to t('views.common.edit'), edit_polymorphic_path([commentable, comment]) %> |
+  <%= link_to t('views.common.destroy'), polymorphic_path([commentable, comment]), method: :delete, data: { confirm: t('views.common.delete_confirm') } %> |
+<% end %>
+
+<%= link_to t('views.common.back'), polymorphic_path(commentable) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,9 @@
           <li>
             <%= link_to User.model_name.human, users_path %>
           </li>
+          <li>
+            <%= link_to Report.model_name.human, reports_path %>
+          </li>
         </ul>
         <div class="title"><%= t('.sign_in_as', email: current_user.email) %></div>
         <ul>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: report) do |form| %>
+  <% if report.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(report.errors.count, "error") %> prohibited this report from being saved:</h2>
+
+      <ul>
+        <% report.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/comments/edit.html.erb
+++ b/app/views/reports/comments/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
+
+<%= render 'comments/comments', commentable: @commentable, comment: @comment %>

--- a/app/views/reports/comments/show.html.erb
+++ b/app/views/reports/comments/show.html.erb
@@ -1,0 +1,1 @@
+<%= render 'comments/show', commentable: @commentable, comment: @comment %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t('views.common.title_edit', name: Report.model_name.human) %></h1>
+
+<%= render 'form', report: @report %>
+
+<%= link_to t('views.common.show'), @report %> |
+<%= link_to t('views.common.back'), reports_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,24 @@
+<h1><%= Report.model_name.human %></h1>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= Report.human_attribute_name(:title) %></th>
+      <th><%= User.human_attribute_name(:name) %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @reports.each do |report| %>
+      <tr>
+        <td><%= report.title %></td>
+        <td><%= report.user_name %></td>
+        <td><%= link_to t('views.common.show'), report %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to t('views.common.new'), new_report_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th><%= Report.human_attribute_name(:title) %></th>
       <th><%= User.human_attribute_name(:name) %></th>
+      <th><%= User.human_attribute_name(:created_at) %></th>
     </tr>
   </thead>
 
@@ -13,6 +14,7 @@
       <tr>
         <td><%= report.title %></td>
         <td><%= report.user_name %></td>
+        <td><%= report.format_time %></td>
         <td><%= link_to t('views.common.show'), report %></td>
       </tr>
     <% end %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('views.common.title_new', name: Report.model_name.human) %></h1>
+
+<%= render 'form', report: @report %>
+
+<%= link_to t('views.common.back'), reports_path %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,3 +1,4 @@
+<h1><%= t('views.common.title_show', name: Report.model_name.human) %></h1>
 <p>
   <strong><%= User.human_attribute_name(:name) %>:</strong>
   <%= @report.user_name %>
@@ -22,4 +23,9 @@
   <%= link_to t('views.common.edit'), edit_report_path(@report) %> |
   <%= link_to t('views.common.destroy'), @report, method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
 <% end %>
+
+<%= render 'comments/index', commentable: @report, comments: @comments %>
+
+<%= render 'comments/form', commentable: @report, comment: Comment.new %>
+
 <%= link_to t('views.common.back'), reports_path %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,25 @@
+<p>
+  <strong><%= User.human_attribute_name(:name) %>:</strong>
+  <%= @report.user_name %>
+</p>
+
+<p>
+  <strong><%= Report.human_attribute_name(:title) %>:</strong>
+  <%= @report.title %>
+</p>
+
+<p>
+  <strong><%= Report.human_attribute_name(:content) %>:</strong>
+  <%= @report.content %>
+</p>
+
+<p>
+  <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+  <%= @report.format_time %>
+</p>
+
+<% if current_user.id == @report.user_id %>
+  <%= link_to t('views.common.edit'), edit_report_path(@report) %> |
+  <%= link_to t('views.common.destroy'), @report, method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+<% end %>
+<%= link_to t('views.common.back'), reports_path %>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -4,6 +4,7 @@ ja:
       book: 本  #g
       user: ユーザ
       report: 日報
+      comment: コメント
     attributes:
       book:
         author: 著者  #g
@@ -19,4 +20,9 @@ ja:
       report:
         content: 内容  #g
         title: タイトル  #g
+        created_at: 作成日時
+      comment:
+        content: 内容
+        user_id: ユーザーID
+        user_name: ユーザー名
         created_at: 作成日時

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,7 +3,7 @@ ja:
     models:
       book: 本  #g
       user: ユーザ
-
+      report: 日報
     attributes:
       book:
         author: 著者  #g
@@ -16,3 +16,7 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         avatar: ユーザ画像
+      report:
+        content: 内容  #g
+        title: タイトル  #g
+        created_at: 作成日時

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
       resources :followers, only: [:index]
     end
   end
+  resources :reports
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'
-  resources :books
+  resources :books do
+    resources :comments, module: :books
+  end
   resources :users, only: %i[index show] do
     resource :relationships, only: %i[create destroy]
     scope module: :users do
@@ -10,5 +12,7 @@ Rails.application.routes.draw do
       resources :followers, only: [:index]
     end
   end
-  resources :reports
+  resources :reports do
+    resources :comments, module: :reports
+  end
 end

--- a/db/migrate/20220530144237_create_report_table.rb
+++ b/db/migrate/20220530144237_create_report_table.rb
@@ -1,0 +1,11 @@
+class CreateReportTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reports do |t|
+      t.text :title, null: false
+      t.text :content, null: false
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220605070922_create_comments.rb
+++ b/db/migrate/20220605070922_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.references :user, foreign_key: true
+      t.references :commentable, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_30_144237) do
+ActiveRecord::Schema.define(version: 2022_06_05_070922) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,17 @@ ActiveRecord::Schema.define(version: 2022_05_30_144237) do
     t.string "picture"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.text "content", null: false
+    t.integer "user_id"
+    t.string "commentable_type"
+    t.integer "commentable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "relationships", force: :cascade do |t|
     t.integer "following_id", null: false
     t.integer "follower_id", null: false
@@ -85,5 +96,6 @@ ActiveRecord::Schema.define(version: 2022_05_30_144237) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_231050) do
+ActiveRecord::Schema.define(version: 2022_05_30_144237) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -58,6 +58,15 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
     t.index ["following_id"], name: "index_relationships_on_following_id"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.text "title", null: false
+    t.text "content", null: false
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -76,4 +85,5 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
日報のCRUDと日報と本にコメントを付けられるようにしました。

# 要件
- [x] 本（books）のCRUDを作ったときの復習として日報（reports）が投稿できるようにする（reportsのCRUDを作る。入力項目はタイトルと本文だけで良い。created_atの日付を日報の投稿日とする）
- [x] 日報を更新・削除できるのはその日報を投稿した本人のみ（本のCRUDは特に制限なし）
- [x] 本と日報の各詳細画面からコメントを投稿できるようにする。
- [x] 投稿したコメントは本と日報の各詳細画面から確認できる。投稿した内容に加えて、投稿したユーザーの名前（未入力ならメアド）と投稿日時も表示する
- [x] 本と日報の各詳細画面でコメントが投稿できている様子をスクショする
- [x] rubocopをパスさせる（要スクリーンショット）

# rubocop
![image](https://user-images.githubusercontent.com/43959158/174427408-b8fac5f6-5986-47b2-805e-b6d7a7ec3913.png)

# スクショ
本
![image](https://user-images.githubusercontent.com/43959158/174427790-c3849a3f-3635-46f6-bfec-f52511a45f8f.png)

日報
![image](https://user-images.githubusercontent.com/43959158/174427827-5398133e-6824-4c74-abf5-067341f3ca12.png)
